### PR TITLE
Conditionally load Prism.js CSS

### DIFF
--- a/src/_includes/components/head.njk
+++ b/src/_includes/components/head.njk
@@ -3,6 +3,9 @@
 <link rel="canonical" href="{{ absolutePostUrl }}">
 <meta name="generator" content="{{ eleventy.generator }}">
 <link rel="stylesheet" href="{{ '/assets/css/index.css' | url }}">
+{% if hasCodeblock %}
+  <link rel="stylesheet" href="{{ '/assets/css/prism.css' | url }}">
+{% endif %}
 <link rel="alternate" href="{{ metadata.feed.path | url }}" type="application/rss+xml" title="{{ metadata.title }}">
 <link rel="alternate" href="{{ metadata.jsonfeed.path | url }}" type="application/json" title="{{ metadata.title }}">
 <link href="{{ '/assets/img/owl-light.png' | url }}" rel="icon" media="(prefers-color-scheme: light)"/>


### PR DESCRIPTION
This PR resolves #11 by adding a verification to the `head.njk` component that conditionally loads Prism.js CSS file only in pages where `hasCodeblock: true` exists in the frontmatter.

 