### PR TITLE
Improve head tags file with variables

### DIFF
--- a/src/_includes/components/head.njk
+++ b/src/_includes/components/head.njk
@@ -1,4 +1,6 @@
 {%- set absolutePostUrl = page.url | absoluteUrl(metadata.url) %}
+{%- set pageTitle = title or renderData.title or metadata.title %}
+{%- set pageDescription = description or renderData.description or metadata.description %}
 
 <link rel="canonical" href="{{ absolutePostUrl }}">
 <meta name="generator" content="{{ eleventy.generator }}">
@@ -12,10 +14,14 @@
 <link href="{{ '/assets/img/owl-dark.png' | url }}" rel="icon" media="(prefers-color-scheme: dark)"/>
 <link rel="me" href="https://mastodon.social/{{ metadata.socialHandle }}">
 
-<title>{{ title or metadata.title }}</title>
-<meta name="description" content="{{ description or metadata.description }}">
+<title>{{ pageTitle }}
+  {% if pageTitle !== metadata.title %}- {{ metadata.title }}
+  {% endif %}
+</title>
+<meta name="description" content="{{ pageDescription }}">
 <meta name="robots" content="index, follow"/>
-<meta property="og:title" content="{{ title or renderData.title or metadata.title }}"/>
+<meta property="og:title" content="{{ pageTitle }}"/>
 <meta property="og:url" content="{{  absolutePostUrl }}"/>
-<meta property="og:description" content="{{ description or renderData.description }}"/>
+<meta property="og:description" content="{{ pageDescription }}"/>
 <meta property="og:type" content="website"/>
+<meta property="og:image" content="https://dynamic-og-image-generator.vercel.app//api/generate?title={{pageTitle}}&author={{metadata.author.name}}&websiteUrl={{metadata.url}}&theme=github"/>


### PR DESCRIPTION
This PR builds on top of https://github.com/paulinhapenedo/11ty-garden/commit/1e1d613b465fa506d021d437353890af9c674428, by applying these changes:

- Create variables for post URL, page title and description at the top of the file for reusability.
- Adds dynamic generated `og:image` by using Vercel's service.

It closes #13. 